### PR TITLE
adding concurrency to _process_resource

### DIFF
--- a/segment_source_resource/sync.py
+++ b/segment_source_resource/sync.py
@@ -28,6 +28,8 @@ def _create_error_handler(collection: str) -> typing.Callable[[Greenlet], None]:
 
 
 def _process_resource(resources: typing.List[Resource], seed: typing.Any, resource: Resource):
+    threads = Pool(10)
+
     for raw_obj in resource.fetch(seed):
         if not isinstance(raw_obj, (Obj, RawObj)):
             raw_obj = RawObj(data=raw_obj, collection=resource.collection, schema=resource.schema)
@@ -38,11 +40,15 @@ def _process_resource(resources: typing.List[Resource], seed: typing.Any, resour
             obj = resource.transform(raw_obj, seed)
 
         source.set(obj.collection, obj.id, obj.properties)
-        _enqueue_children(resources, raw_obj, resource)
+        thread = threads.spawn(_enqueue_children, resources, raw_obj, resource)
+        thread.link_exception(_create_error_handler(resource.collection))
+
+    threads.join()
 
 
 def _enqueue_children(resources: typing.List[Resource], seed: typing.Any, parent: Resource):
-    threads = Pool(5)
+    threads = Pool(10)
+
     for resource in [r for r in resources if r.parent == parent.name]:
         prepared_seed = parent.get_subresource_fetch_arg(seed, resource)
         if prepared_seed is None:
@@ -55,7 +61,7 @@ def _enqueue_children(resources: typing.List[Resource], seed: typing.Any, parent
 
 
 def execute(resources: typing.List[Resource], seed: typing.Any = None):
-    threads = Pool(5)
+    threads = Pool(10)
     for resource in [r for r in resources if not r.parent]:
         thread = threads.spawn(_process_resource, resources, seed, resource)
         thread.link_exception(_create_error_handler(resource.collection))


### PR DESCRIPTION
@tejasmanohar pointed out that within _process_resource, we end
up processing each child *serially*, because each _enqueue_children
call actually waits to execute. This call should help speed up
the collections with many children.

@tejasmanohar @andreiko 