### PR TITLE
Logging in cwlogs format for python sources

### DIFF
--- a/segment_source_resource/log.py
+++ b/segment_source_resource/log.py
@@ -1,0 +1,136 @@
+import logging
+import collections
+import sys
+import datetime
+import structlog
+import contextlib
+import gevent
+
+
+def cwlogs_processor(_, method_name, event_dict):
+    new = collections.OrderedDict()
+    new['time'] = datetime.datetime.now().isoformat() + 'Z'
+    new['level'] = method_name
+    new['message'] = event_dict.pop('event')
+    new['data'] = event_dict
+    return new
+
+
+class Discard(object):
+    def write(self, b):
+        pass
+
+
+class FilteringLogger(object):
+    def __init__(self, level):
+        self.level = level
+
+    def isEnabledFor(self, level):
+        return self.level <= level
+
+
+def bound_filter_by_level(level):
+    logger = FilteringLogger(level)
+
+    def processor(_, method_name, event_dict):
+        return structlog.stdlib.filter_by_level(logger, method_name, event_dict)
+
+    return processor
+
+
+def greenlet_handler(**kwargs):
+    def handler(greenlet):
+        error("Greenlet crashed", exc_info=greenlet.exc_info, **kwargs)
+
+    return handler
+
+
+def add_global_values(global_values):
+    def processor(_, __, event_dict):
+        for key, value in global_values.items():
+            if key not in event_dict:
+                event_dict[key] = value
+        return event_dict
+
+    return processor
+
+
+def std_processor(_, method_name, event_dict):
+    event_dict['_record'] = event_dict['data'].pop('_record')
+    event_dict['data']['logger'] = event_dict['_record'].name
+    return event_dict
+
+
+def configure(levelname, **global_values):
+    try:
+        level = structlog.stdlib.INFO
+        if levelname:
+            level = structlog.stdlib._NAME_TO_LEVEL[levelname]
+    except KeyError:
+        raise ValueError("Unknown log level: '%s'" % levelname)
+
+    pre_chain = [
+        # format_exc_info adds "exception" key with a traceback if it's available
+        structlog.processors.format_exc_info,
+        add_global_values(global_values),
+        cwlogs_processor,
+    ]
+    processors = list(pre_chain)
+    processors.extend([
+        structlog.processors.JSONRenderer(),
+        bound_filter_by_level(level),
+    ])
+    pre_chain.append(std_processor)
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=structlog.threadlocal.wrap_dict(dict),
+    )
+
+    # capturing all messages from standard python logging
+    std_handler = logging.StreamHandler(stream=sys.stdout)
+    std_handler.setFormatter(structlog.stdlib.ProcessorFormatter(
+        processor=structlog.processors.JSONRenderer(),
+        foreign_pre_chain=pre_chain,
+    ))
+    std_logger = logging.getLogger()
+    std_logger.addHandler(std_handler)
+    std_logger.setLevel(level)
+
+    # don't output raw exceptions of failed greenlets
+    gevent.get_hub().exception_stream = Discard()
+
+
+def bind_global(**kwargs):
+    structlog.get_logger().bind(**kwargs)
+
+
+@contextlib.contextmanager
+def bind(**kwargs):
+    with structlog.threadlocal.tmp_bind(structlog.get_logger(), **kwargs):
+        yield
+
+
+def debug(message, **kwargs):
+    structlog.get_logger().debug(message, **kwargs)
+
+
+def info(message, **kwargs):
+    structlog.get_logger().info(message, **kwargs)
+
+
+def warning(message, **kwargs):
+    structlog.get_logger().warning(message, **kwargs)
+
+
+def error(message, **kwargs):
+    structlog.get_logger().error(message, **kwargs)
+
+
+def critical(message, **kwargs):
+    structlog.get_logger().critical(message, **kwargs)
+
+
+def exception(message, **kwargs):
+    structlog.get_logger().exception(message, **kwargs)

--- a/segment_source_resource/resource.py
+++ b/segment_source_resource/resource.py
@@ -1,11 +1,12 @@
 import datetime
 import numbers
-import logging
 import typing
 
 from dateutil.parser import parse as parse_date
 from dateutil.tz import tzlocal
 from pydash import get
+
+from . import log
 
 
 def parse_datetime(timestamp: typing.Union[datetime.datetime, str]) -> str:
@@ -130,7 +131,7 @@ class Resource(object):
                 raise ValueError(message) from err
 
         if not obj_id:
-            logging.warning("raw object without id: collection=%s properties=%s", raw_obj.collection, raw_obj.data)
+            log.warning("raw object without id", collection=raw_obj.collection, properties=raw_obj.data)
 
         return Obj(
             id=obj_id,

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'gevent',
         'python-dateutil',
         'segment_source==0.12.0',
+        'structlog',
     ],
     tests_require=['pytest'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
before:
```
WARNING:retry.api:

  Message: Call was not successful
  Method:  GET
  Path:    https://graph.facebook.com/v2.10/6054997905162/insights
  Params:  {'date_preset': 'lifetime', 'action_attribution_windows': 'default', 'fields': 'frequency,impressions,ad_id,social_impressions,unique_clicks,unique_social_clicks,inline_post_engagement,clicks,date_stop,spend,call_to_action_clicks,date_start,social_spend,social_clicks,reach,actions', 'time_increment': 1, 'action_breakdowns': 'action_type,action_link_click_destination'}

  Status:  400
  Response:
    {
      "error": {
        "message": "Unsupported get request.",
        "fbtrace_id": "ADRHdh4QifZ",
        "code": 100,
        "type": "GraphMethodException"
      }
    }
, retrying in 5 seconds...
WARNING:requests.packages.urllib3.connectionpool:Connection pool is full, discarding connection: graph.facebook.com
```

after:
```
{"time": "2017-11-22T19:33:30.629684Z", "level": "warning", "message": "Connection pool is full, discarding connection: graph.facebook.com", "data": {"logger": "requests.packages.urllib3.connectionpool", "program": "facebook-ads", "version": "0.12.9"}}
{"time": "2017-11-22T19:33:32.158741Z", "level": "warning", "message": "\n\n  Message: Call was not successful\n  Method:  GET\n  Path:    https://graph.facebook.com/v2.10/6054997905162/insights\n  Params:  {'fields': 'date_stop,spend,impressions,date_start,inline_post_engagement,social_impressions,reach,clicks,unique_clicks,call_to_action_clicks,social_clicks,ad_id,social_spend,frequency,unique_social_clicks,actions', 'date_preset': 'lifetime', 'action_attribution_windows': 'default', 'time_increment': 1, 'action_breakdowns': 'action_type,action_link_click_destination'}\n\n  Status:  400\n  Response:\n    {\n      \"error\": {\n        \"type\": \"GraphMethodException\",\n        \"fbtrace_id\": \"Fw15+eCuZpk\",\n        \"message\": \"Unsupported get request.\",\n        \"code\": 100\n      }\n    }\n, retrying in 5 seconds...", "data": {"logger": "retry.api", "program": "facebook-ads", "version": "0.12.9"}}
```
